### PR TITLE
Include templates folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ import { toFonts } from 'icon-builder';
 }
 ```
 About `out`:
+
 - `string`: the output path of css / html file.
 - `true`: the output path is the same as the fonts path.
 - `false`: no emit css / html file.
@@ -63,9 +64,11 @@ About `out`:
 By default, `css.out` is `true`, `html.out` is `false`.
 
 About `template`:
+
 Templates must be coded in [Handlebars](https://handlebarsjs.com) (`.hbs`) format. See [`templates` folder](https://github.com/Codpoe/icon-builder/tree/master/templates) as a reference.
 
 About `options`:
+
 This is any extra data passed to the Handlebars template set in `template`.
 
 ## React components

--- a/README.md
+++ b/README.md
@@ -91,4 +91,4 @@ import { toReact } from 'icon-builder';
 
 Before building the icon font, it is best to convert the SVG icons from stroke to fill.
 
-For example, sketch / layer / convert to outlines.
+For example: Sketch > Layer > Convert to outlines

--- a/README.md
+++ b/README.md
@@ -67,9 +67,13 @@ About `template`:
 
 Templates must be coded in [Handlebars](https://handlebarsjs.com) (`.hbs`) format. See [`templates` folder](https://github.com/Codpoe/icon-builder/tree/master/templates) as a reference.
 
+This is optional.
+
 About `options`:
 
 This is any extra data passed to the Handlebars template set in `template`.
+
+This is optional.
 
 ## React components
 ```js

--- a/README.md
+++ b/README.md
@@ -6,18 +6,18 @@
 
 An icon builder, forked from [webfonts-generator](https://github.com/sunflowerdeath/webfonts-generator)
 
-- 🎉Support `svg`, `ttf`, `woff`, `woff2`, `eot`
-- 💥Covert svg icons to react components
-- 🥊Develop with TypeScript
-- ✅Pass test
-- 👀Friendly preview
+- 🎉 Supports: `svg`, `ttf`, `woff`, `woff2`, `eot`
+- 💥 Converts SVG icons to React components
+- 🥊 Developed with TypeScript
+- ✅ Passes all tests
+- 👀 Friendly preview
 
 ## Install
 ```
 yarn add icon-builder
 ```
 
-## iconfont
+## Usage
 ```js
 import { toFonts } from 'icon-builder';
 
@@ -62,7 +62,7 @@ About `out`:
 
 By default, `css.out` is `true`, `html.out` is `false`.
 
-## react components
+## React components
 ```js
 import { toReact } from 'icon-builder';
 
@@ -76,6 +76,6 @@ import { toReact } from 'icon-builder';
 
 ## Note
 
-Before building the iconfont, it's best to convert the svg icons from stroke to fill.
+Before building the icon font, it is best to convert the SVG icons from stroke to fill.
 
 For example, sketch / layer / convert to outlines.

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ import { toFonts } from 'icon-builder';
 ```js
 {
   out: true, // string | boolean
-  template: TEMPLATES.css / TEMPLATE.html,
+  template: 'path/to/the/template.hbs',
   options: {},
 }
 ```
@@ -61,6 +61,12 @@ About `out`:
 - `false`: no emit css / html file.
 
 By default, `css.out` is `true`, `html.out` is `false`.
+
+About `template`:
+Templates must be coded in [Handlebars](https://handlebarsjs.com) (`.hbs`) format. See [`templates` folder](https://github.com/Codpoe/icon-builder/tree/master/templates) as a reference.
+
+About `options`:
+This is any extra data passed to the Handlebars template set in `template`.
 
 ## React components
 ```js

--- a/README.md
+++ b/README.md
@@ -13,11 +13,13 @@ An icon builder forked from [webfonts-generator](https://github.com/sunflowerdea
 - 👀 Generates a friendly preview in HTML
 
 ## Install
-```
-yarn add icon-builder
+
+```sh
+$ yarn add icon-builder
 ```
 
 ## Usage
+
 ```js
 import { toFonts } from 'icon-builder';
 
@@ -48,6 +50,7 @@ import { toFonts } from 'icon-builder';
 | html | `object` | | HTML config |
 
 ### css / html config
+
 ```js
 {
   out: true, // string | boolean
@@ -55,6 +58,7 @@ import { toFonts } from 'icon-builder';
   options: {},
 }
 ```
+
 #### `out`
 
 - `string`: The output path of CSS/HTML file.
@@ -76,6 +80,7 @@ This is any extra data passed to the Handlebars template set in `template`.
 This is optional.
 
 ## React components
+
 ```js
 import { toReact } from 'icon-builder';
 
@@ -89,6 +94,6 @@ import { toReact } from 'icon-builder';
 
 ## Note
 
-Before building the icon font, it is best to convert the SVG icons from stroke to fill.
+Before building the icon font, it is recommended to convert the SVG icons from stroke to fill.
 
-For example: Sketch > Layer > Convert to outlines
+For example: *Sketch* > *Layer* > *Convert to outlines*

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ import { toFonts } from 'icon-builder';
   options: {},
 }
 ```
-About `out`:
+#### `out`
 
 - `string`: the output path of css / html file.
 - `true`: the output path is the same as the fonts path.
@@ -63,13 +63,13 @@ About `out`:
 
 By default, `css.out` is `true`, `html.out` is `false`.
 
-About `template`:
+#### `template`
 
 Templates must be coded in [Handlebars](https://handlebarsjs.com) (`.hbs`) format. See [`templates` folder](https://github.com/Codpoe/icon-builder/tree/master/templates) as a reference.
 
 This is optional.
 
-About `options`:
+#### `options`
 
 This is any extra data passed to the Handlebars template set in `template`.
 

--- a/README.md
+++ b/README.md
@@ -57,9 +57,9 @@ import { toFonts } from 'icon-builder';
 ```
 #### `out`
 
-- `string`: the output path of css / html file.
-- `true`: the output path is the same as the fonts path.
-- `false`: no emit css / html file.
+- `string`: The output path of CSS/HTML file.
+- `true`: The output path is the same as the fonts path (see `out` in [Options](#options)).
+- `false`: No emit CSS/HTML file.
 
 By default, `css.out` is `true`, `html.out` is `false`.
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 ![David](https://img.shields.io/david/codpoe/icon-builder.svg)
 ![npm](https://img.shields.io/npm/v/icon-builder.svg)
 
-An icon builder, forked from [webfonts-generator](https://github.com/sunflowerdeath/webfonts-generator)
+An icon builder forked from [webfonts-generator](https://github.com/sunflowerdeath/webfonts-generator).
 
 - 🎉 Supports: `svg`, `ttf`, `woff`, `woff2`, `eot`
 - 💥 Converts SVG icons to React components
@@ -34,18 +34,18 @@ import { toFonts } from 'icon-builder';
 
 | option | type | default | description |
 |---|---|---|---|
-| src | `string` | | required |
+| src | `string` | | Required |
 | out | `string` / `false` | `false` | |
 | fontName | `string` | `'iconfont'` | |
 | classPrefix | `string` | `'icon-'` | |
-| hash | `boolean` | `true` | use hash |
-| types | `array` | `['svg', 'ttf', 'eot', 'woff', 'woff2']` | font types |
+| hash | `boolean` | `true` | Use hash |
+| types | `array` | `['svg', 'ttf', 'eot', 'woff', 'woff2']` | Font types |
 | startCodepoint | `number` | `0xf101` | |
-| codepoints | `object` | `{}` | unicode start |
+| codepoints | `object` | `{}` | Unicode start |
 | normalize | `boolean` | `true` | |
 | centerHorizontally | `boolean` | `true` | |
-| css | `object` | | css config |
-| html | `object` | | html config |
+| css | `object` | | CSS config |
+| html | `object` | | HTML config |
 
 ### css / html config
 ```js

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ An icon builder, forked from [webfonts-generator](https://github.com/sunflowerde
 - 💥 Converts SVG icons to React components
 - 🥊 Developed with TypeScript
 - ✅ Passes all tests
-- 👀 Friendly preview
+- 👀 Generates a friendly preview in HTML
 
 ## Install
 ```

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "types": "types/index.d.ts",
   "files": [
     "lib",
+    "templates",
     "types"
   ],
   "scripts": {

--- a/src/render-css.ts
+++ b/src/render-css.ts
@@ -19,7 +19,7 @@ const makeUrlMap = (opts: ToFontsOptions, hashStr?: string): UrlMap => {
 
   opts.types.forEach(
     (type): void => {
-      const fontName = `${opts.fontName}${hashStr ? `_${hashStr}` : ''}.${type}`;
+      const fontName = `${opts.fontName}${opts.hash && hashStr ? `_${hashStr}` : ''}.${type}`;
       res[type] = path.join(cssFontsUrl, fontName);
     }
   );

--- a/templates/html.hbs
+++ b/templates/html.hbs
@@ -4,7 +4,7 @@
 	<meta charset="UTF-8">
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
 	<meta http-equiv="X-UA-Compatible" content="ie=edge">
-	<title>{{fontName}} - {{names.length}}</title>
+	<title>{{fontName}} - {{names.length}} icons</title>
 	<style>
 		* {
 			box-sizing: border-box;


### PR DESCRIPTION
- Include [`templates` folder](https://github.com/Codpoe/icon-builder/tree/master/templates) in published module. This fixes an issue in which template files are not found when `css.out` and/or `html.out` are set to `true` and no `css.template` and/or `html.template` are set in [options](https://github.com/Codpoe/icon-builder#options)
- Fix some typos in `README.md`
- Improve some texts in `README.md`
- Fix an issue in which hash is included in an URL although it was set to `false` in [options](https://github.com/Codpoe/icon-builder#options)