### PR TITLE
Add codepoints to HTML template context

### DIFF
--- a/src/render-html.ts
+++ b/src/render-html.ts
@@ -20,6 +20,7 @@ const renderHtml = (opts: ToFontsOptions): string => {
   });
 
   const ctx = {
+    codepoints: opts.codepoints,
     names: opts.names,
     fontName: opts.fontName,
     classPrefix: opts.classPrefix,

--- a/src/render-html.ts
+++ b/src/render-html.ts
@@ -8,6 +8,12 @@ import { ToFontsOptions } from './types/index';
 const renderHtml = (opts: ToFontsOptions): string => {
   const source = fs.readFileSync(opts.html.template as string, 'utf8');
   const template = handlebars.compile(source);
+  
+  const codepoints: { [key: string]: string } = {};
+  // Transform codepoints to hex strings
+  Object.keys(opts.codepoints).forEach((name): void => {
+    codepoints[name] = opts.codepoints[name].toString(16);
+  });
 
   // Styles embedded in the html file should use default CSS template and
   // have path to fonts that is relative to html file location.
@@ -20,7 +26,7 @@ const renderHtml = (opts: ToFontsOptions): string => {
   });
 
   const ctx = {
-    codepoints: opts.codepoints,
+    codepoints,
     names: opts.names,
     fontName: opts.fontName,
     classPrefix: opts.classPrefix,


### PR DESCRIPTION
Changes make possible to display unicode characters in the generated HTML file; for example:
```hbs
<div class="items">
  {{#each codepoints}}
  <div class="item" data-clipboard-text="{{../classPrefix}}{{@key}}">
    <div class="item-icon-wrapper">
      <span class="item-icon"><i class="{{../classPrefix}}{{@key}}"></i></span>
    </div>
    <div class="item-content">
      <div class="item-name">{{../classPrefix}}{{@key}}</div>
      <div class="item-unicode">\\{{this}}</div>
    </div>
  </div>
  {{/each}}
</div>
```